### PR TITLE
fix: drop importing LED settings from a theme

### DIFF
--- a/src/internal/themes/import.go
+++ b/src/internal/themes/import.go
@@ -103,11 +103,11 @@ func ImportTheme(themeName string) error {
 	}
 
 	// Apply LED settings directly from manifest
-	if manifest.Content.Settings.LEDsIncluded {
-		if err := applyLEDSettings(manifest, logger); err != nil {
-			logger.DebugFn("Warning: Error applying LED settings: %v", err)
-		}
-	}
+	// if manifest.Content.Settings.LEDsIncluded {
+	// 	if err := applyLEDSettings(manifest, logger); err != nil {
+	// 		logger.DebugFn("Warning: Error applying LED settings: %v", err)
+	// 	}
+	// }
 
 	logger.DebugFn("Theme import completed successfully: %s", themeName)
 


### PR DESCRIPTION
LEDs are usually set manually by users and can even be done on a per-console or game basis, and thus do not really belong in themes. It is removed in this commit to avoid issues where users have to go back and reset their LED settings after adding a theme.